### PR TITLE
Make it easier to pass test_None on a database that requires primary keys

### DIFF
--- a/dbapi20.py
+++ b/dbapi20.py
@@ -782,6 +782,9 @@ class DatabaseAPI20Test(unittest.TestCase):
         try:
             cur = con.cursor()
             self.executeDDL2(cur)
+            # inserting NULL to the second column, because some drivers might
+            # need the first one to be primary key, which means it needs
+            # to have a non-NULL value
             cur.execute("%s into %sbarflys values ('a', NULL)" % (self.insert, self.table_prefix))
             cur.execute('select drink from %sbarflys' % self.table_prefix)
             r = cur.fetchall()

--- a/dbapi20.py
+++ b/dbapi20.py
@@ -782,8 +782,8 @@ class DatabaseAPI20Test(unittest.TestCase):
         try:
             cur = con.cursor()
             self.executeDDL1(cur)
-            cur.execute('%s into %sbooze values (NULL)' % (self.insert, self.table_prefix))
-            cur.execute('select name from %sbooze' % self.table_prefix)
+            cur.execute("%s into %sbarflys values ('a', NULL)" % (self.insert, self.table_prefix))
+            cur.execute('select drink from %sbarflys' % self.table_prefix)
             r = cur.fetchall()
             self.assertEqual(len(r),1)
             self.assertEqual(len(r[0]),1)

--- a/dbapi20.py
+++ b/dbapi20.py
@@ -781,7 +781,7 @@ class DatabaseAPI20Test(unittest.TestCase):
         con = self._connect()
         try:
             cur = con.cursor()
-            self.executeDDL1(cur)
+            self.executeDDL2(cur)
             cur.execute("%s into %sbarflys values ('a', NULL)" % (self.insert, self.table_prefix))
             cur.execute('select drink from %sbarflys' % self.table_prefix)
             r = cur.fetchall()


### PR DESCRIPTION
I'm running the tests on a database that can't have tables without primary keys, so I have modified the `ddlX` attributes in my subclass, but `test_None` currently tries to insert `NULL` into the only column in the table, so that fails.

This change should modify the behavior of the test, but makes it easier to change the tables, so that the first column is a primary key.
